### PR TITLE
Do not permit OAUTH_CONSUMER_SECRET to be nil

### DIFF
--- a/app/models/customer_token.rb
+++ b/app/models/customer_token.rb
@@ -15,7 +15,7 @@ class CustomerToken < ActiveRecord::Base
   validates_presence_of :expires_at, :issue_id
   before_create :generate_token
 
-  OAUTH_CONSUMER_SECRET = Setting.plugin_redmine_qbo['settingsOAuthConsumerSecret']
+  OAUTH_CONSUMER_SECRET = Setting.plugin_redmine_qbo['settingsOAuthConsumerSecret'] || 'CONFIGURE_QBO__' + SecureRandom.uuid
   
   def generate_token
     self.token = SecureRandom.base64(15).tr('+/=lIO0', OAUTH_CONSUMER_SECRET)


### PR DESCRIPTION
When QBO plugin is not configured, OAUTH_CONSUMER_SECRET can be
nil, and any codepath hitting the model raises a stack trace.

Set a "safe-ish" value here to allow execution in conditions where
QBO plugin is installed, but not yet configured.